### PR TITLE
Improvements on code

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,13 @@ sudo bash script.bash start -u=pi -dir=/home/pi/s-mon -lib_dir=/home/pi/common-p
 sudo bash script.bash -h
 ```
 
-## API
+## APIs
 
-### GET
-`/api/system/service/stats/SERVICE_ID` # returns an uptime
-`/api/system/service/up/SERVICE_ID`  # returns a true/false
+### GET APIs
+- For returning an uptime: `/api/system/service/stats/<service>`
+- For returning a `true`/`false`: `/api/system/service/up/<service>`
 
-example is top get the status of rubix-wires
-
-Options for the services
-
+Options for the `<service>` are:
 ```
 WIRES = 'nubeio-rubix-wires.service'
 PLAT = 'nubeio-wires-plat.service'
@@ -34,35 +31,38 @@ BAC_SERVER = 'nubeio-wires-plat.service'  # TODO
 DRAC = 'nubeio-wires-plat.service'  # TODO
 ```
 
-
+Example is top get the status of rubix-wires:
 ```
 http://0.0.0.0:1616/api/system/service/stats/wires
 http://0.0.0.0:1616/api/system/service/up/wires
 ```
 
 
-### POST
+### POST APIs
 
-`action`
-```
-START = start a service
-STOP = start a service
-RESTART = restart a service
-```
+For `start|stop|restart` services: 
 
-`service`
-service to start/stop/restart
+> POST: `/api/system/service`
 
-Body
-```
+> Body
+```json
 {
-    "action": "start",
-    "service": "wires"
+    "action": "<action>",
+    "service": "<service>"
 }
 ```
 
-## Updater
+Where `<action>` are:
+- `start`: for starting a service
+- `stop`: for stopping a service
+- `restart`: for restarting a service
 
+> Example:
+```bash
+curl -X POST http://localhost:1616/api/system/service -H "Content-Type: application/json" -d '{"action": "restart","service":"wires"}'
+```
+
+## Updater
 
 ```
 Step 1:
@@ -84,29 +84,38 @@ WIRES-PLAT: POST {service: WIRES, action: status}: S-MON RETURN service status
 ```
 
 
-### HTTP POST download
-/api/services/download
+### Download
+> POST: `/api/services/download`
 
-Body
-```
+> Body
+```json
 {
     "service": "BAC_SERVER",
-    "directory": "/home/aidan/code/test",
-    "build_url": "https://api.github.com/repos/NubeDev/bacnet-flask/zipball/v1.1.1"
+    "dir": "/home/pi/bacnet-server-auto",
+    "build_url": "https://api.github.com/repos/NubeDev/bacnet-flask/zipball/v1.1.3"
 }
 ```
-
-### HTTP POST install
-/api/services/install
-if `test_install": true` is true then this will not run the system command (This is used for testing the API)
-
-Body
+>Examples:
+```bash
+curl -X POST http://localhost:1616/api/services/download -H "Content-Type: application/json" -d '{"service":"BAC_SERVER","dir":"/home/pi/bacnet-server-auto","build_url":"https://api.github.com/repos/NubeDev/bacnet-flask/zipball/v1.1.3"}'
+curl -X POST http://localhost:1616/api/services/download -H "Content-Type: application/json" -d '{"service":"WIRES","dir":"/home/pi/wires-builds-auto","build_url":"https://api.github.com/repos/NubeIO/wires-builds/zipball/v1.8.2"}'
 ```
+
+
+### Install
+> POST: `/api/services/install`
+
+> Body
+```json
 {   
     "service": "BAC_SERVER",
-    "_dir": "/home/aidan/code/test",
-     "user": "AIDAN",
-    "lib_dir": "/home/aa/",
-    "test_install": true
+    "dir": "/home/pi/bacnet-server-auto",
+    "user": "pi",
+    "lib_dir": "/home/pi/common-py-libs"
 }
+```
+> Examples:
+```bash
+curl -X POST http://localhost:1616/api/services/install  -H "Content-Type: application/json" -d '{"service":"BAC_SERVER","dir":"/home/pi/bacnet-server-auto","user":"pi","lib_dir":"/home/pi/common-py-libs"}'
+curl -X POST http://localhost:1616/api/services/install  -H "Content-Type: application/json" -d '{"service":"WIRES","dir":"/home/pi/wires-builds-auto","user":"pi"}'
 ```

--- a/script.bash
+++ b/script.bash
@@ -12,7 +12,7 @@ COMMAND=""
 
 help() {
     echo "Service commands:"
-    echo -e "   ${GREEN}start -u=<user> -dir=<working_dir> -lib_dir=<lib_dir>${DEFAULT}   Start the service (-u=pi -dir=/home/pi/backend-${version}-${sha})"
+    echo -e "   ${GREEN}start -u=<user> -dir=<working_dir> -lib_dir=<lib_dir>${DEFAULT}   Start the service (-u=pi -dir=/home/pi/s-mon -lib_dir=/home/pi/common-py-lib)"
     echo -e "   ${GREEN}disable${DEFAULT}                                                 Disable the service"
     echo -e "   ${GREEN}enable${DEFAULT}                                                  Enable the stopped service"
     echo -e "   ${GREEN}delete${DEFAULT}                                                  Delete the service"

--- a/src/routes.py
+++ b/src/routes.py
@@ -1,4 +1,5 @@
 from flask_restful import Api
+
 from src import app
 from src.platform.resource_wires_plat import WiresPlatResource
 from src.system.networking.bbb_ip import BBB_DHCP, BBB_STAIC
@@ -11,19 +12,18 @@ from src.system.resources.updater import DownloadService, InstallService
 api_prefix = 'api'
 api = Api(app)
 
-api.add_resource(GetSystemTime, "/{}/system/time".format(api_prefix))
-api.add_resource(GetSystemMem, "/{}/system/memory".format(api_prefix))
-api.add_resource(GetSystemDiscUsage, "/{}/system/disc".format(api_prefix))
-api.add_resource(SystemctlCommand, "/{}/system/service".format(api_prefix))
-api.add_resource(SystemctlStatusBool, "/{}/system/service/up/<string:service>".format(api_prefix))
-api.add_resource(SystemctlStatus, "/{}/system/service/stats/<string:service>".format(api_prefix))
-api.add_resource(NetworkInfo, "/{}/system/networking".format(api_prefix))
-api.add_resource(BBB_DHCP, "/{}/system/networking/update/bbb/dhcp".format(api_prefix))
-api.add_resource(BBB_STAIC, "/{}/system/networking/update/bbb/static".format(api_prefix))
-api.add_resource(DownloadService, "/{}/services/download".format(api_prefix))
-api.add_resource(InstallService, "/{}/services/install".format(api_prefix))
-api.add_resource(Ping, "/{}/ping".format(api_prefix))
-
+api.add_resource(GetSystemTime, "/{api_prefix}/system/time")
+api.add_resource(GetSystemMem, f"/{api_prefix}/system/memory")
+api.add_resource(GetSystemDiscUsage, f"/{api_prefix}/system/disc")
+api.add_resource(SystemctlCommand, f"/{api_prefix}/system/service")
+api.add_resource(SystemctlStatusBool, f"/{api_prefix}/system/service/up/<string:service>")
+api.add_resource(SystemctlStatus, f"/{api_prefix}/system/service/stats/<string:service>")
+api.add_resource(NetworkInfo, f"/{api_prefix}/system/networking")
+api.add_resource(BBB_DHCP, f"/{api_prefix}/system/networking/update/bbb/dhcp")
+api.add_resource(BBB_STAIC, f"/{api_prefix}/system/networking/update/bbb/static")
+api.add_resource(DownloadService, f"/{api_prefix}/services/download")
+api.add_resource(InstallService, f"/{api_prefix}/services/install")
+api.add_resource(Ping, f"/{api_prefix}/ping")
 
 wires_api_prefix = f'{api_prefix}/wires'
 api.add_resource(WiresPlatResource, f'/{wires_api_prefix}/plat')

--- a/src/system/resources/ping.py
+++ b/src/system/resources/ping.py
@@ -17,9 +17,11 @@ class Ping(Resource):
     def get(self):
         up_time = get_up_time()
         up_min = up_time / 60
-        up_min = round(up_min, 2)
-        up_min = str(up_min)
+        up_min = "{:.2f}".format(up_min)
         up_hour = up_time / 3600
-        up_hour = round(up_hour, 2)
-        up_hour = str(up_hour)
-        return {'up_time_date': up_time_date, 'up_min': up_min, 'up_hour': up_hour}
+        up_hour = "{:.2f}".format(up_hour)
+        return {
+            'up_time_date': up_time_date,
+            'up_min': up_min,
+            'up_hour': up_hour
+        }

--- a/src/system/resources/test.py
+++ b/src/system/resources/test.py
@@ -1,2 +1,0 @@
-
-# print(tz_string)

--- a/src/system/resources/updater.py
+++ b/src/system/resources/updater.py
@@ -1,78 +1,11 @@
 import os
-import time
+
 from flask_restful import Resource, reqparse, abort
-from src.system.services import Services
-from io import BytesIO
-from urllib.request import urlopen
-from zipfile import ZipFile
-from pathlib import Path
-import shutil
+
+from src.system.services import validate_installation_service, InstallableServices
+from src.system.utils.file import delete_existing_folder, download_unzip_service, get_extracted_dir
 from src.system.utils.shell_commands import execute_command
-from src.system.utils.url_check import service_urls, IsValidURL
-
-path_global = ""
-
-
-def set_path_global(_dir):
-    global path_global
-    path_global = _dir.split('/')[0]
-
-
-def get_path_global():
-    return path_global
-
-
-def delete_existing_folder(_dir):
-    dir_path = Path(_dir)
-    if dir_path.exists() and dir_path.is_dir():
-        shutil.rmtree(dir_path)
-        return True
-    else:
-        return False
-
-
-def download_unzip_service(service, _dir):
-    try:
-        with urlopen(service) as zip_resp:
-            with ZipFile(BytesIO(zip_resp.read())) as z_file:
-                z_file.extractall(_dir)
-                dirs = list(set([os.path.dirname(x) for x in z_file.namelist()]))
-                set_path_global(dirs[0])
-                get_path_global()
-                return True
-    except FileNotFoundError:
-        return False
-
-
-def build_install_cmd(_dir, user, lib_dir):
-    build_dir = "{}/{}".format(_dir, get_path_global())
-    cmd = "sudo bash script.bash start -u={} -dir={} -lib_dir={}".format(user, build_dir, lib_dir)
-    return [cmd, build_dir]
-
-
-def build_install_cmd_wires(_dir, user):
-    wires_path = 'rubix-wires'
-    build_dir = "{}/{}/{}".format(_dir, get_path_global(), wires_path)
-    cmd = "bash script.bash start -u={} -hp={} -l=false".format(user, build_dir)
-    return [cmd, build_dir]
-
-
-def build_install(cmd, test, cwd):
-    if test:
-        time.sleep(5)
-        return True
-    run = execute_command(cmd, cwd)
-    if not run:
-        return False
-    else:
-        return True
-
-
-def _validate_service(service) -> str:
-    if service.upper() in Services.__members__.keys():
-        return service_urls.get(service)
-    else:
-        abort(400, message="service {} does not exist in our system".format(service))
+from src.system.utils.url_check import ServiceURL
 
 
 class DownloadService(Resource):
@@ -80,52 +13,72 @@ class DownloadService(Resource):
         parser = reqparse.RequestParser()
         parser.add_argument('service', type=str, required=True)
         parser.add_argument('build_url', type=str, required=True)
-        parser.add_argument('directory', type=str, required=True)
+        parser.add_argument('dir', type=str, required=True)
         args = parser.parse_args()
-        _service = args['service']
+        service = args['service'].upper()
         build_url = args['build_url']
-        directory = args['directory']
-        service = _validate_service(_service)
-        if not service:
-            abort(400, message="service {} does not exist in our system".format(service))
-        url = IsValidURL(build_url, _service)
-        service_url = url.service_to_url()
-        check_url = url.check_url(service_url)
-        if not check_url:
-            abort(400, message="service {} is an invalid url".format(service))
-        delete_existing_dir = delete_existing_folder(directory)
-        download = download_unzip_service(build_url, directory)
+        dir_ = args['dir']
+        does_service_exist = validate_installation_service(service)
+        if not does_service_exist:
+            abort(404, message=f"service {service} does not exist in our system")
+        service_url = ServiceURL(build_url, service)
+        if not service_url.is_valid():
+            abort(400, message=f"service {service} is an invalid build_url")
+        delete_existing_dir = delete_existing_folder(dir_)
+        download = download_unzip_service(build_url, dir_)
         if not download:
-            abort(400, message="valid URL service {} but download failed check internet!".format(service))
-        return {'service': service, 'service_to_url': service_url, 'del_existing_dir': delete_existing_dir}
+            abort(501, message=f"valid URL service {service} but download failed check internet or version!")
+        return {'service': service, 'build_url': build_url, 'dir': dir_, 'del_existing_dir': delete_existing_dir}
 
 
 class InstallService(Resource):
     def post(self):
         parser = reqparse.RequestParser()
         parser.add_argument('service', type=str, required=True)
-        parser.add_argument('_dir', type=str, required=True)
+        parser.add_argument('dir', type=str, required=True)
         parser.add_argument('user', type=str, required=True)
         parser.add_argument('lib_dir', type=str, required=False)
-        parser.add_argument('test_install', type=bool, required=True)
         args = parser.parse_args()
-        _service = args['service']
-        _dir = args['_dir']
+        service = args['service'].upper()
+        dir_ = args['dir']
         user = args['user']
         lib_dir = args['lib_dir']
-        test_install = args['test_install']
-        service = _validate_service(_service)
-        if not service:
-            abort(400, message="service {} does not exist in our system".format(service))
-        if _service == "WIRES":
-            build_cmd = build_install_cmd_wires(_dir, user)
-            install = build_install(build_cmd[0], test_install, build_cmd[1])
-            if not install:
-                abort(400, message="valid service {} issue on install, build cmd: {}".format(service, build_cmd))
-            return {'service': service, 'build_cmd': build_cmd, 'install_completed': install}
-        elif _service == "BAC_REST" or _service == "BAC_SERVER":
-            build_cmd = build_install_cmd(_dir, user, lib_dir)
-            install = build_install(build_cmd[0], test_install, build_cmd[1])
-            if not install:
-                abort(400, message="valid service {} issue on install, build cmd: {}".format(service, build_cmd))
-            return {'service': service, 'build_cmd': build_cmd, 'install_completed': install}
+        does_service_exist = validate_installation_service(service)
+        if not does_service_exist:
+            abort(400, message=f"service {service} does not exist in our system")
+        if service == InstallableServices.WIRES.name:
+            wd_and_cwd = _get_wd_and_cwd_wires(dir_)
+            cwd = wd_and_cwd['cwd']
+            cmd = _get_install_cmd_wires(user, wd_and_cwd['wd'])
+        else:
+            cwd = _get_cwd_apps(dir_)
+            cmd = _get_install_cmd_apps(user, cwd, lib_dir)
+
+        install = execute_command(cmd, cwd)
+        if not install:
+            abort(400, message=f"valid service {service} issue on install, build cmd: {cmd} on working dir: {cwd}")
+        return {'service': service, 'cmd': cmd, cwd: 'cwd', 'install_completed': install}
+
+
+def _get_cwd_apps(dir_) -> str:
+    cwd = get_extracted_dir(dir_)
+    if not cwd:
+        abort(f"Check {dir_}, we don't have any files inside this dir")
+    return cwd
+
+
+def _get_wd_and_cwd_wires(dir_) -> dict:
+    return {
+        'wd': os.path.join(_get_cwd_apps(dir_), 'rubix-wires'),  # working dir for systemd
+        'cwd': os.path.join(_get_cwd_apps(dir_), 'rubix-wires/systemd')  # current working dir for script.bash execution
+    }
+
+
+def _get_install_cmd_apps(user, wd, lib_dir) -> str:
+    cmd = f"sudo bash script.bash start -u={user} -dir={wd} -lib_dir={lib_dir}"
+    return cmd
+
+
+def _get_install_cmd_wires(user, wd) -> str:
+    cmd = f"sudo bash script.bash start -u={user} -dir={wd}"
+    return cmd

--- a/src/system/services.py
+++ b/src/system/services.py
@@ -1,12 +1,26 @@
 import enum
 
 
+class InstallableServices(enum.Enum):
+    WIRES = 'nubeio-rubix-wires.service'
+    BAC_REST = 'nubeio-bac-rest.service'
+    BAC_SERVER = 'nubeio-bacnet-server.service'
+
+
 class Services(enum.Enum):
     WIRES = 'nubeio-rubix-wires.service'
+    BAC_REST = 'nubeio-bac-rest.service'
+    BAC_SERVER = 'nubeio-bacnet-server.service'
     PLAT = 'nubeio-wires-plat.service'
     LORAWAN = 'lorawan-server'
     MOSQUITTO = 'mosquitto.service'
     BBB = 'nubeio-bbio.service'
-    BAC_REST = 'nubeio-bac-rest.service'
-    BAC_SERVER = 'nubeio-bacnet-server.service'
     DRAC = 'nubeio-drac.service'  # TODO
+
+
+def validate_installation_service(service) -> bool:
+    return service in InstallableServices.__members__.keys()
+
+
+def validate_service(service) -> bool:
+    return service in Services.__members__.keys()

--- a/src/system/utils/file.py
+++ b/src/system/utils/file.py
@@ -1,0 +1,35 @@
+import os
+import shutil
+from io import BytesIO
+from pathlib import Path
+from urllib.request import urlopen
+from zipfile import ZipFile
+
+
+def delete_existing_folder(dir_):
+    dir_path = Path(dir_)
+    if dir_path.exists() and dir_path.is_dir():
+        shutil.rmtree(dir_path)
+        return True
+    else:
+        return False
+
+
+def download_unzip_service(url, directory):
+    try:
+        with urlopen(url) as zip_resp:
+            with ZipFile(BytesIO(zip_resp.read())) as z_file:
+                z_file.extractall(directory)
+                return True
+    except FileNotFoundError:
+        return False
+
+
+def get_extracted_dir(home_dir) -> str:
+    try:
+        dirs = os.listdir(home_dir)
+        if len(dirs):
+            return os.path.join(home_dir, dirs[0])
+    except Exception as e:
+        print(e)
+    return ""

--- a/src/system/utils/url_check.py
+++ b/src/system/utils/url_check.py
@@ -1,3 +1,5 @@
+from src.system.services import InstallableServices
+
 wires_domain = (
     'api.github.com',
     'NubeIO',
@@ -16,31 +18,29 @@ bacnet_flask_domain = (
     'bacnet-flask'
 )
 
-service_urls = {
-    'WIRES': 'https://api.github.com/repos/NubeIO/wires-builds/releases',
-    'BAC_REST': 'https://api.github.com/repos/NubeDev/bac-rest/releases',
-    'BAC_SERVER': 'https://api.github.com/repos/NubeDev/bacnet-flask/releases'
-}
 
-
-class IsValidURL:
+class ServiceURL:
     def __init__(self, url, service):
         self.url = url
         self.service = service
 
-    def service_to_url(self):
-        if self.service == 'WIRES':
+    def _get_service_url_tuple(self):
+        if self.service == InstallableServices.WIRES.name:
             return wires_domain
-        elif self.service == 'BAC_REST':
+        elif self.service == InstallableServices.BAC_REST.name:
             return bac_rest_domain
-        elif self.service == 'BAC_SERVER':
+        elif self.service == InstallableServices.BAC_SERVER.name:
             return bacnet_flask_domain
 
-    def check_url(self, url_to_check):
+    def _check_service_url_tuple(self, service_url_tuple) -> bool:
         u = self.url.split("/")
         domain = (u[2], u[4], u[5])
-        print(domain, url_to_check)
-        if url_to_check == domain:
-            return True
+        print("URL check:", domain, service_url_tuple)
+        return service_url_tuple == domain
+
+    def is_valid(self):
+        service_url_tuple = self._get_service_url_tuple()
+        if service_url_tuple:
+            return self._check_service_url_tuple(service_url_tuple)
         else:
             return False


### PR DESCRIPTION
Resolves: #8

### Summary:

- Make `download`/`install` services clean and working

```bash
curl -X POST http://localhost:1616/api/services/download -H "Content-Type: application/json" -d '{"service":"BAC_SERVER","dir":"/home/pi/bacnet-server-auto","build_url":"https://api.github.com/repos/NubeDev/bacnet-flask/zipball/v1.1.3"}'
curl -X POST http://localhost:1616/api/services/download -H "Content-Type: application/json" -d '{"service":"WIRES","dir":"/home/pi/wires-builds-auto","build_url":"https://api.github.com/repos/NubeIO/wires-builds/zipball/v1.8.2"}'
curl -X POST http://localhost:1616/api/services/install  -H "Content-Type: application/json" -d '{"service":"BAC_SERVER","dir":"/home/pi/bacnet-server-auto","user":"pi","lib_dir":"/home/pi/common-py-libs"}'
curl -X POST http://localhost:1616/api/services/install  -H "Content-Type: application/json" -d '{"service":"WIRES","dir":"/home/pi/wires-builds-auto","user":"pi"}'
```

### Note:
**Following arguments are changed on the request, which may needs to update on frontend:**

- On downloading part: `directory` is changed into `dir`
- On installing part: `_dir` is changed into `dir` and `test_install` argument is removed out